### PR TITLE
Use options.versionDescription when creating an application version

### DIFF
--- a/tasks/awsebtdeploy.js
+++ b/tasks/awsebtdeploy.js
@@ -413,6 +413,7 @@ module.exports = function (grunt) {
       return qAWS.createApplicationVersion({
         ApplicationName: options.applicationName,
         VersionLabel: options.versionLabel,
+        Description: options.versionDescription,
         SourceBundle: {
           S3Bucket: options.s3.bucket,
           S3Key: options.s3.key


### PR DESCRIPTION
Hello,

I integrated your plugin and everything is working pretty smoothly, but I noticed that we are not sending the application version's description. This one line change seems to fix the issue for me.

Thanks,
Tom
