### PR TITLE
Added new "manual" deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The archive needs to be created in advance of running the task, for instance wit
 
 * Type: `String` 
 * Default: `inPlace`  
-* Allowed values: `inPlace`, `swapToNew`
+* Allowed values: `inPlace`, `swapToNew`, `manual`
 
 The type of the deployment to run, more on this below.
 
@@ -243,7 +243,7 @@ A health check can be configured using two options: `options.healthPage` and `op
 
 ## Deployment types
 
-Two deployment types are supported, which can be configured in the task options. 
+Three deployment types are supported, which can be configured in the task options. 
 There is a common sequence of internal operations followed by all deployment types, which correspond to 
 [AWS SDK operations](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/frames.html).
 
@@ -253,7 +253,7 @@ There is a common sequence of internal operations followed by all deployment typ
 4. `createApplicationVersion` to create a new application version from the S3 object
 5. _any deployment type-specific logic, described below_
 
-### inPlace
+### `inPlace`
 
 The deploy is done to the currently running environment, therefore a downtime will happen while the
 environment refreshes after the update.
@@ -267,7 +267,7 @@ code is 200 and, if `options.healthPageContents` is set, until the body of the r
 
 > This deployment type is safe for non-production environments where there is no need to guarantee uptime
 
-### swapToNew 
+### `swapToNew`
 
 A flavor of *blue/green* deployment where a new environment is created with the same settings as the current one, 
 the application is deployed to the new environment and finally the CNAMEs of the environments are swapped 
@@ -294,6 +294,10 @@ to requests made to the old environment url
 
 
 > This deployment type is more appropriate for production environments, but compared to `inPlace` it creates new resources and can potentially disrupt the functionality of the environment in case any step goes wrong, which would require manual intervention, for example to swap CNAMEs again to the old, untouched environment    
+
+### `manual`
+
+Manual deployment. The source bundle will be uploaded to S3, and a new application version will be ready and waiting to be deployed.
 
 
 ## The **awsebtlogs** task

--- a/tasks/awsebtdeploy.js
+++ b/tasks/awsebtdeploy.js
@@ -9,13 +9,13 @@
 'use strict';
 
 module.exports = function (grunt) {
-  var AWS = require('aws-sdk'),
-      path = require('path'),
-      fs = require('fs'),
-      get = require('http').get,
-      sget = require('https').get,
-      util = require('util'),
-      Q = require('q'),
+  var AWS    = require('aws-sdk'),
+      path   = require('path'),
+      fs     = require('fs'),
+      get    = require('http').get,
+      sget   = require('https').get,
+      util   = require('util'),
+      Q      = require('q'),
       mkdirp = require('mkdirp');
 
   function findEnvironmentByCNAME(data, cname) {
@@ -27,11 +27,11 @@ module.exports = function (grunt) {
   }
 
   function createEnvironmentName(applicationName) {
-    var maxLength = 23,
-        time = new Date().getTime().toString(),
-        timeLength = time.length,
+    var maxLength      = 23,
+        time           = new Date().getTime().toString(),
+        timeLength     = time.length,
         availableSpace = maxLength - applicationName.length,
-        timePart = time.substring(timeLength - availableSpace, timeLength);
+        timePart       = time.substring(timeLength - availableSpace, timeLength);
 
     if (applicationName.length > maxLength - 3)
       grunt.log.subhead('Warning: application name is too long to guarantee ' +
@@ -79,10 +79,10 @@ module.exports = function (grunt) {
           intervalSec: 2
         }),
         awsOptions = setupAWSOptions(options),
-        eb = new AWS.ElasticBeanstalk(awsOptions),
-        request = Q.nbind(eb.requestEnvironmentInfo, eb),
-        retrieve = Q.nbind(eb.retrieveEnvironmentInfo, eb),
-        args = { EnvironmentName: options.environmentName, InfoType: 'tail' };
+        eb         = new AWS.ElasticBeanstalk(awsOptions),
+        request    = Q.nbind(eb.requestEnvironmentInfo, eb),
+        retrieve   = Q.nbind(eb.retrieveEnvironmentInfo, eb),
+        args       = { EnvironmentName: options.environmentName, InfoType: 'tail' };
 
     grunt.log.writeln('Requesting logs for environment ' + options.environmentName + '...');
 
@@ -181,8 +181,8 @@ module.exports = function (grunt) {
       }
     }
 
-    var task = this,
-        done = this.async(),
+    var task    = this,
+        done    = this.async(),
         options = this.options({
           versionDescription: '',
           deployType: 'inPlace',
@@ -192,7 +192,7 @@ module.exports = function (grunt) {
           healthPageIntervalSec: 10
         }),
         awsOptions = setupAWSOptions(options),
-        qAWS = wrapAWS(new AWS.ElasticBeanstalk(awsOptions), new AWS.S3(awsOptions));
+        qAWS       = wrapAWS(new AWS.ElasticBeanstalk(awsOptions), new AWS.S3(awsOptions));
 
     validateOptions();
 


### PR DESCRIPTION
This adds a new `deployType: 'manual'` option which uploads the deploy archive to S3, creates a new version on Elastic Beanstalk, but leaves final deployment step to be done "manually". 

I considered making this the default, since I almost made the mistake of deploying code to our live production environment while initially testing this plugin! :worried:

P.S. There is some code-style and documentation stuff in the 2nd commit. If you don't like these changes feel free to cherry-pick the 1st commit.
