### PR TITLE
Ensure that only valid environment names are created

### DIFF
--- a/tasks/awsebtdeploy.js
+++ b/tasks/awsebtdeploy.js
@@ -38,7 +38,12 @@ module.exports = function (grunt) {
           'a unique environment name, maximum length ' +
           maxLength + ' characters');
 
-    return applicationName + timePart;
+    if (/^[a-zA-Z0-9\-]+$/.test(applicationName))
+      return applicationName + timePart;
+
+    grunt.log.subhead('Notice: application name contains invalid characters ' +
+        'for a environment name; stripping everything non letter, digit, or dash');
+    return applicationName.replace(/[^a-zA-Z0-9\-]+/g, "") + timePart;
   }
 
   function wrapAWS(eb, s3) {


### PR DESCRIPTION
Since the only constraint on Application Names is <100 characters, but the constraints on environments are tighter (letters, numbers, dashes, 23 characters, see http://docs.aws.amazon.com/elasticbeanstalk/latest/APIReference/API_CreateEnvironment.html), the createEnvironment task could let junk through without a way to correct it.

This PR throws a tiny notice and then adjusts the return if we would otherwise attempt to create an invalid environment name.
