### PR TITLE
Do not add CNAME grunt warning for manual deployment type

### DIFF
--- a/tasks/awsebtdeploy.js
+++ b/tasks/awsebtdeploy.js
@@ -481,8 +481,12 @@ module.exports = function (grunt) {
             var env = findEnvironmentByCNAME(data, options.environmentCNAME);
 
             if (!env) {
-              grunt.log.error();
-              grunt.warn('Environment with CNAME "' + options.environmentCNAME + '" does not exist');
+              if (options.deployType === 'manual') {
+                grunt.log.write('Environment with CNAME "' + options.environmentCNAME + '" does not exist but is not required for manual deployment');
+              } else {
+                grunt.log.error();
+                grunt.warn('Environment with CNAME "' + options.environmentCNAME + '" does not exist');
+              }
             }
 
             grunt.log.ok();


### PR DESCRIPTION
This prevents `grunt.warning` for missing CNAME if `options.deployType` is set to `manual`. 

As `manual` is only uploading a new version to the application there is no need to provide a CNAME.
